### PR TITLE
Add @tensorfeed/mcp-server (AI-supply-chain IOC feed) to AppSec section

### DIFF
--- a/mcp_security_servers_and_integrations.md
+++ b/mcp_security_servers_and_integrations.md
@@ -28,6 +28,7 @@
 | [addcontent/nuclei-mcp][link_addcontent_nuclei_mcp] | [Nuclei][link_projectdiscovery_nuclei]-driven scanning via MCP | **High risk** if pointed at non-owned targets; auth and rate limits mandatory | ![](https://badgen.net/github/last-commit/addcontent/nuclei-mcp) |
 | [elliotllliu/agent-shield][link_elliotllliu_agent_shield] | Pre-deployment scanning for agent skills, MCP servers, and plugins | Offline-focused static analysis for injection-style risks; still requires human review of findings | ![](https://badgen.net/github/last-commit/elliotllliu/agent-shield) |
 | [prompt-security/clawsec][link_prompt_security_clawsec] | Audit pipeline for agent skills and MCP servers | Multi-stage analysis; validate where data/artefacts are stored and how reports are generated | ![](https://badgen.net/github/last-commit/prompt-security/clawsec) |
+| [@tensorfeed/mcp-server][link_tensorfeed_mcp_server] | General TensorFeed.ai catalog MCP (news, status, model data) with a dedicated `get_ai_supply_chain_iocs` tool surfacing the daily AI-keyword-filtered GHSA feed across npm, PyPI, Go, Maven, and other ecosystems | Pure data feed, no scanning or code execution; daily refresh from GitHub Security Advisories; treat the linked GHSA record as authoritative. Useful as a single AI-relevant defender feed for MCP-server reviewers and supply-chain monitors | ![](https://badgen.net/github/last-commit/RipperMercs/tensorfeed) |
 
 ---
 
@@ -204,3 +205,4 @@ These projects often combine **identity, scoring, payments (for example x402)**,
 [link_zinja_jadx_ai_mcp]: https://github.com/zinja-coder/jadx-ai-mcp
 [link_mobilehackinglab_jadx_mcp_plugin]: https://github.com/mobilehackinglab/jadx-mcp-plugin
 [link_zitadel]: https://zitadel.com/
+[link_tensorfeed_mcp_server]: https://github.com/RipperMercs/tensorfeed


### PR DESCRIPTION
## Summary

Adds **@tensorfeed/mcp-server** to the *AppSec, SAST, dependencies, and supply chain* table.

TensorFeed.ai is an AI ecosystem catalog that ships an MCP server with a dedicated **`get_ai_supply_chain_iocs`** tool. The tool surfaces a daily-refreshed list of GitHub Security Advisory entries filtered by AI/ML/LLM/MCP keyword vocabulary across npm, PyPI, Go, Maven, and other package ecosystems.

## Why it fits this list

- **Republish posture, not a scanner.** TF re-publishes already-public GHSA advisories with an AI-relevance filter on top. The linked GHSA record is always treated as authoritative. No malware detection, no attribution, no active scanning of the agent's environment.
- **Single AI-relevant defender feed.** Useful for MCP-server reviewers, AI-tool maintainers, and supply-chain monitors that want one curated stream of AI-touching advisories instead of polling all of GHSA.
- **Tool annotations conform to the MCP spec.** `readOnlyHint: true`, `destructiveHint: false`, `idempotentHint: true`, `openWorldHint: true`. Read-only HTTPS calls to the public TensorFeed Worker; no credentials required for this tool.
- **Pre-existing track record.** The underlying feed flagged the @mistralai npm worm on day 1 of publication.

## Entry placement

Inserted under *AppSec, SAST, dependencies, and supply chain*, after `prompt-security/clawsec`. Matches the existing table format (Server | Role | Summary | Last-updated badge). New reference link added to the link defs block.

## Verification

- **npm package**: https://www.npmjs.com/package/@tensorfeed/mcp-server
- **MCP registry**: `ai.tensorfeed/mcp-server` (listed at https://registry.modelcontextprotocol.io)
- **Source repo**: https://github.com/RipperMercs/tensorfeed (Apache-2.0)
- **Live feed**: https://tensorfeed.ai/api/security/ai-supply-chain-iocs.json

Thank you for maintaining this list.