### PR TITLE
Add Pluto AgentGuard to MCP Scanners section

### DIFF
--- a/mcp_security_tools.md
+++ b/mcp_security_tools.md
@@ -32,6 +32,7 @@ For MCP servers that expose **external security products** (Semgrep, Burp, Shoda
 | **[Ant Group MCP-Security][link_github_com_antgroup_mcp_security]** | Static + dynamic MCP scanner — Auditing agent tools / plugins; **detects** malicious metadata (prompt injection), insecure tools, unsafe reads, code vulns. Semgrep-style taint + dynamic LLM eval; local or remote GitHub repos. |
 | **[MCPServer Audit][link_github_com_modelcontextprotocol_security_mcpserver_audit]** | MCP server audit — Pre-use safety checks; publishing to audit/DB; output per audit workflow. Community initiative — verify maturity / evidence format. |
 | **[MCPSafetyScanner][link_github_com_leidosinc_mcpsafetyscanner]** | Agentic MCP safety auditor — Adversarial samples from tools/resources; safety reports; **detects** unsafe tools, malicious execution, credential theft, unauthorized access. Research / academic; **safety:** isolated test env only. |
+| **[Pluto AgentGuard][link_github_com_arpitha_dhanapathi_pluto_aguard]** | MCP config scanner + policy tester → Static analysis of MCP configs for dangerous servers, hardcoded secrets, missing auth, context safety gaps; **plus** policy coverage testing (22 attack scenarios), what-if risk simulation, OWASP-inspired control mapping, baseline drift detection, and launch evidence generation. Offline, no API keys; validated against 1,200 real GitHub MCP configs. |
 | **[MCP-SandboxScan][link_github_com_wapiti08_mcp_sandboxscan]** | Runtime / sandbox analysis — Execute untrusted tools in WASM/WASI-style sandbox; **detects** env/file→prompt, filesystem violations, runtime-only issues. Research / experimental; advanced research & high-risk tool review. |
 | **[MCP Inspector][link_github_com_modelcontextprotocol_inspector]** ([documentation][link_modelcontextprotocol_io_docs_tools_inspector]) | Dev test/debug (not a security scanner) — Manual inspection of servers, tools, prompts, resources, transport; observational only (no automated detection). For security review: validate tools/schemas before approval; **not** a replacement for automated scanning. |
 
@@ -195,3 +196,4 @@ For MCP servers that expose **external security products** (Semgrep, Burp, Shoda
 [link_sentinelone]: https://www.sentinelone.com/platform/singularity-xdr/
 [link_carbon_black]: https://www.broadcom.com/products/cyber-security/endpoint
 [link_sophos_intercept_x]: https://www.sophos.com/en-us/products/endpoint-antivirus
+[link_github_com_arpitha_dhanapathi_pluto_aguard]: https://github.com/arpitha-dhanapathi/pluto-aguard


### PR DESCRIPTION
## Addition

Adding [Pluto AgentGuard](https://github.com/arpitha-dhanapathi/pluto-aguard) to the MCP Scanners table.

### Why it's relevant:
Unlike pure config scanners, Pluto AgentGuard combines static MCP analysis with:
- **Policy coverage testing** — 22 attack scenarios across 6 packs (prompt injection, data exfil, privilege escalation, approval bypass, tool poisoning, context manipulation)
- **What-if risk simulation** — model policy changes and see risk delta before applying
- **OWASP-inspired control mapping** — 20 controls aligned with OWASP Agentic AI
- **Baseline drift detection** and **launch readiness evidence packets**

### Validation:
Scanned 1,200 real MCP configs from 1,159 public GitHub repos. Results: 13% had HIGH-severity findings (unauthenticated remote endpoints). Severity grounded in MCP spec architecture (HITL is client responsibility) and OWASP Agentic AI framework.

### Details:
- Apache-2.0 | Python 3.10+ | pip-installable
- CLI: `aguard scan/test/whatif/owasp/evidence/baseline/monitor`
- GitHub Action included | SARIF output | 135 tests
- Fully offline, no API keys or cloud dependency